### PR TITLE
Fix log for illegal arguments

### DIFF
--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -1564,18 +1564,39 @@ function log(x, base){
         x = $.x,
         base = $.base
     if(_b_.isinstance(x, $B.long_int)){
+        if(x.value <= 0){
+            throw _b_.ValueError.$factory("math domain error")
+        }
         var log = $B.long_int.$log2(x).value * Math.LN2
     }else{
+        if(x <= 0){
+            throw _b_.ValueError.$factory("math domain error")
+        }
         var x1 = float_check(x),
             log = Math.log(x1)
-    }
-    if(x1 <= 0){
-        throw _b_.ValueError.$factory("math domain error")
     }
     if(base === _b_.None){
         return $B.fast_float(log)
     }
-    return $B.fast_float(log / Math.log(float_check(base)))
+
+    function check_base(b) {
+        if (b == 1) {
+            // The way Python does it
+            throw _b_.ZeroDivisionError.$factory("float division by zero")
+        }
+        if (b <= 0) {
+            throw _b_.ValueError.$factory("math domain error")
+        }
+    }
+
+    if (_b_.isinstance(base, $B.long_int)) {
+        check_base(base.value)
+        var log_base = $B.long_int.$log2(base).value * Math.LN2
+    } else {
+        check_base(base)
+        var log_base = Math.log(float_check(base))
+    }
+    return $B.fast_float(log / log_base)
 }
 
 function log1p(x){

--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -1569,11 +1569,11 @@ function log(x, base){
         }
         var log = $B.long_int.$log2(x).value * Math.LN2
     }else{
+        x = float_check(x)
         if(x <= 0){
             throw _b_.ValueError.$factory("math domain error")
         }
-        var x1 = float_check(x),
-            log = Math.log(x1)
+        var log = Math.log(x)
     }
     if(base === _b_.None){
         return $B.fast_float(log)

--- a/www/src/libs/math.js
+++ b/www/src/libs/math.js
@@ -1569,7 +1569,7 @@ function log(x, base){
         var x1 = float_check(x),
             log = Math.log(x1)
     }
-    if(x1 == 0){
+    if(x1 <= 0){
         throw _b_.ValueError.$factory("math domain error")
     }
     if(base === _b_.None){
@@ -1588,6 +1588,10 @@ function log1p(x){
         }
         x = $B.long_int.$log2($B.fast_long_int(x.value + 1n))
         return $B.fast_float(Number(x.value) * Math.LN2)
+    }
+    x = float_check(x)
+    if(x + 1 <= 0){
+        throw _b_.ValueError.$factory("math domain error")
     }
     return $B.fast_float(Math.log1p(float_check(x)))
 }
@@ -1608,8 +1612,9 @@ function log2(x){
     if(isNaN(x)){
         return _b_.float.$factory('nan')
     }
+    // idk dont ask me
     if(x < 0.0){
-        throw _b_.ValueError.$factory('')
+        throw _b_.ValueError.$factory('math domain error')
     }
     return $B.fast_float(Math.log(x) / Math.LN2)
 }
@@ -1621,7 +1626,7 @@ function log10(x){
         return $B.fast_float($B.long_int.$log10(x).value)
     }
     x = float_check(x)
-    if(x == 0){
+    if(x <= 0){
         throw _b_.ValueError.$factory("math domain error")
     }
     return $B.fast_float(Math.log10(x))

--- a/www/tests/test_math.py
+++ b/www/tests/test_math.py
@@ -302,6 +302,16 @@ assert_raises(ValueError, math.log10, -1, msg="math domain error")
 assert_raises(ValueError, math.log2, -1, msg="math domain error")
 assert_raises(ValueError, math.log1p, -2, msg="math domain error")
 
+# long_int tests
+long_int = 2 << 70
+assert_raises(ValueError, math.log, -long_int, msg="math domain error")
+assert_raises(ValueError, math.log, long_int, -long_int, msg="math domain error")
+assert_raises(ZeroDivisionError, math.log, long_int, 1, msg="float division by zero")
+assert_raises(ValueError, math.log, long_int, 0, msg="math domain error")
+assert_raises(ValueError, math.log10, -long_int, msg="math domain error")
+assert_raises(ValueError, math.log2, -long_int, msg="math domain error")
+assert_raises(ValueError, math.log1p, -long_int, msg="math domain error")
+
 
 # rewriting of math.comb
 math.comb(1200, 575)

--- a/www/tests/test_math.py
+++ b/www/tests/test_math.py
@@ -292,6 +292,17 @@ assert_raises(ValueError, math.log, 0, msg="math domain error")
 assert_raises(ValueError, math.log10, 0, msg="math domain error")
 assert_raises(ValueError, math.log2, 0, msg="math domain error")
 
+# negative args and illegal bases
+assert_raises(ValueError, math.log, -1, msg="math domain error")
+assert_raises(ZeroDivisionError, math.log, 2, 1, msg="float division by zero")
+assert_raises(ZeroDivisionError, math.log, 1, 1, msg="float division by zero")
+assert_raises(ValueError, math.log, 2, -1, msg="math domain error")
+assert_raises(ValueError, math.log, 2, 0, msg="math domain error")
+assert_raises(ValueError, math.log10, -1, msg="math domain error")
+assert_raises(ValueError, math.log2, -1, msg="math domain error")
+assert_raises(ValueError, math.log1p, -2, msg="math domain error")
+
+
 # rewriting of math.comb
 math.comb(1200, 575)
 


### PR DESCRIPTION
- Calling log10, log1p, log with negative argument now raises a ValueError.
- Adds message to ValueError raised when calling log2 with negative argument.
- Log with negative base raises ValueError.
- Log with base 1 raises ZeroDivisionError.