### PR TITLE
open function event

### DIFF
--- a/www/src/py_builtin_functions.js
+++ b/www/src/py_builtin_functions.js
@@ -3036,8 +3036,17 @@ $B.set_func_names($TextIOWrapper, "builtins")
 $B.Reader = $Reader
 $B.TextIOWrapper = $TextIOWrapper
 $B.BufferedReader = $BufferedReader
+$B.EventTarget = new EventTarget()
 
 var $url_open = _b_.open = function(){
+    $B.EventTarget.dispatchEvent(new CustomEvent(
+      'function-call',
+      {
+        detail: {
+          function: '_b_.open'
+        },
+      }
+    ))
     // first argument is file : can be a string, or an instance of a DOM File object
     var $ = $B.args('open', 3, {file: null, mode: null, encoding: null},
         ['file', 'mode', 'encoding'], arguments,


### PR DESCRIPTION
- Fixes #2304 : JS Error instead of syntax error for invalid Python code (if + not)
- Add unicode.txt to outputs
- Fixes #2303 : JS error instead of syntax error for invalid Python code
- Set url2name, imported, and file_cache when script is run if not already set
- Emit an event when the open() function is called
